### PR TITLE
Fixed wrong import for the SoundCloud module

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -236,6 +236,7 @@ except TypeError:
     pagesblanche = None
     possible_mail = None
     skype2mail = None
+    diplomess = None
     pren = ""
     name = ""  
 

--- a/profiler.py
+++ b/profiler.py
@@ -41,7 +41,7 @@ from modules  import mail_gen
 from modules  import scylla_sh
 from modules  import mail_check
 from modules  import last_diplomes
-from modules  import soundclound
+from modules  import soundcloud
 from modules.visual      import logging
 from modules.api_modules import leakcheck_net
 


### PR DESCRIPTION
The previous import was throwing an ImportError because the name was 'soundclound'.